### PR TITLE
fix(inline-blame): changed cursor to cursor line in show argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Show git blame information as virtual text next to the current line you're editi
 ```toml
 [editor]
 # Inline blame configuration (inline table form)
-inline-blame = { show = "cursor", format = "{author} • {time-ago} • {title}", auto-fetch = false }
+inline-blame = { show = "cursor-line", format = "{author} • {time-ago} • {title}", auto-fetch = false }
 ```
 
 Or in expanded format:
@@ -398,8 +398,8 @@ Or in expanded format:
 ```toml
 [editor.inline-blame]
 # Show inline blame on specific lines (default: "never")
-# Options: "cursor", "all", "never"
-show = "cursor"
+# Options: "cursor-line", "all", "never"
+show = "cursor-line"
 
 # Format string for blame display
 # Available placeholders: {author}, {commit}, {time-ago}, {title}
@@ -418,12 +418,12 @@ auto-fetch = false
 ```toml
 # Minimal blame display
 [editor.inline-blame]
-show = "cursor"
+show = "cursor-line"
 format = "{author} • {time-ago}"
 
 # Detailed blame information
 [editor.inline-blame]
-show = "cursor"
+show = "cursor-line"
 format = "{commit} - {author} ({time-ago}): {title}"
 
 # Show blame for all lines (can be noisy)


### PR DESCRIPTION
Hi there, first of all thanks for the great work on this fork!

I noticed a small error in the documentation for the inline-blame feature. The README incorrectly referred to the argument as cursor when it should be cursor-line.

This PR corrects all occurrences in the README to use the proper cursor-line argument.

Version: 25.10.09.03
Platform: macOS (Apple Silicon)

