### PR TITLE
Make overlays (e.g. pickers) fullscreen - original helix PR [#12311](https://github.com/helix-editor/helix/pull/12311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,3 +509,13 @@ periodic.interval = 5000
 focus-gained = true
 periodic.enable = true
 periodic.interval = 5000
+```
+
+### Picker Full Screen
+
+Enables that pickers cover full screen instead of only 90%
+
+```toml
+[editor]
+pickers-full-screen = true
+```

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -67,6 +67,7 @@
 | `editor-config` | Whether to read settings from [EditorConfig](https://editorconfig.org) files | `true` |
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
+| `pickers-full-screen` | if pickers should be full screen. | `false` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
 
@@ -293,9 +294,9 @@ name = "rust"
 
 ### `[editor.auto-reload]` Section
 
-Controls auto reloading of externally modified files.
 
 | Key | Description | Default |
+|--|--|---------|
 |--|--|---------|
 | `focus-gained` | Enable automatic reloading of externally modified files when Helix is focused. Requires [focus event support](https://github.com/helix-editor/helix/wiki/Terminal-Support) from your terminal | `false` |
 | `periodic.enable` | Enable periodic auto reloading of externally modified files | `false` |

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -18,15 +18,13 @@ pub struct Overlay<T> {
 }
 
 /// Surrounds the component with a margin of 5% on each side, and an additional 2 rows at the bottom
-pub fn overlaid<T>(content: T) -> Overlay<T> {
+pub fn overlaid<T>(content: T, ctx: &Context) -> Overlay<T> {
     Overlay {
         content,
         calc_child_size: Box::new(|rect: Rect| {
-            let percentage = if rect.width < FULL_OVERLAID_MAX_WIDTH {
-                100
-            } else {
-                90
-            };
+            let overlay_full_screen =
+                ctx.editor.config().pickers_full_screen && rect.width < FULL_OVERLAID_MAX_WIDTH;
+            let percentage = if overlay_full_screen { 100 } else { 90 };
             clip_rect_relative(rect.clip_bottom(2), percentage, percentage)
         }),
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -499,6 +499,8 @@ pub struct Config {
     /// Completion Highlight configuration
     #[serde(default)]
     pub completion_highlight: CompletionHighlight,
+    /// If pickers should be full screen
+    pub pickers_full_screen: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1643,6 +1645,7 @@ impl Default for Config {
             gradient_borders: GradientBorderConfig::default(),
             notifications: NotificationConfig::default(),
             completion_highlight: CompletionHighlight::default(),
+            pickers_full_screen: false,
         }
     }
 }


### PR DESCRIPTION
Porting this improvement from the original helix PR [#12311](https://github.com/helix-editor/helix/pull/12311). As it's simple change and it improves the editor.

I like the minimal look and that it adds a bit more of the preview space.

## Old behaviour:
<img width="1496" height="937" alt="Screenshot 2025-11-13 at 09 31 25" src="https://github.com/user-attachments/assets/94f106c5-318e-4075-86a4-ca9d51bb66cf" />

## New behaviour:
<img width="1489" height="935" alt="Screenshot 2025-11-13 at 09 32 15" src="https://github.com/user-attachments/assets/a205c2c7-2293-40f4-9ede-b414de890977" />

