### PR TITLE
fix(warnings): clearing all the warnings that come up. Mostly unused stuff

### DIFF
--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -956,7 +956,7 @@ impl Display for ApplyEditErrorKind {
 
 /// Precondition: `locations` should be non-empty.
 fn goto_impl(
-    title: &'static str,
+    _title: &'static str,
     editor: &mut Editor,
     compositor: &mut Compositor,
     locations: Vec<Location>,

--- a/helix-term/src/commands/notification.rs
+++ b/helix-term/src/commands/notification.rs
@@ -73,9 +73,11 @@ pub fn test_notifications(cx: &mut Context) {
     log::warn!("DEBUG: Creating notification with timeout: {:?} ({}ms)", config.default_timeout, timeout_ms);
     
     // Create a simple test notification
-    let id = cx.editor.notify_info(format!("Test notification (timeout: {}ms) - should disappear in {}s", 
-                                          timeout_ms, timeout_ms as f64 / 1000.0));
-    
+    let _id = cx.editor.notify_info(format!(
+        "Test notification (timeout: {}ms) - should disappear in {}s",
+        timeout_ms,
+        timeout_ms as f64 / 1000.0
+    ));
     // Check if the notification was created with timeout
     let all_notifications = cx.editor.get_notification_history();
     if let Some(notification) = all_notifications.last() {

--- a/helix-term/src/handlers/document_colors.rs
+++ b/helix-term/src/handlers/document_colors.rs
@@ -5,11 +5,10 @@ use helix_core::{syntax::config::LanguageServerFeature, text_annotations::Inline
 use helix_event::{cancelable_future, register_hook};
 use helix_lsp::lsp;
 use helix_view::{
-    DocumentId, Editor, Theme,
     document::DocumentColorSwatches,
     events::{DocumentDidChange, DocumentDidOpen, LanguageServerExited, LanguageServerInitialized},
     handlers::{lsp::DocumentColorsEvent, Handlers},
-    icons::ICONS,
+    DocumentId, Editor, Theme,
 };
 use tokio::time::Instant;
 
@@ -128,8 +127,6 @@ fn attach_document_colors(
     let mut color_swatches = Vec::with_capacity(doc_colors.len());
     let mut color_swatches_padding = Vec::with_capacity(doc_colors.len());
     let mut colors = Vec::with_capacity(doc_colors.len());
-
-    let icons = ICONS.load();
 
     for (pos, color) in doc_colors {
         color_swatches_padding.push(InlineAnnotation::new(pos, " "));

--- a/helix-term/src/ui/cmdline_popup.rs
+++ b/helix-term/src/ui/cmdline_popup.rs
@@ -1,11 +1,11 @@
 use crate::compositor::{Component, Context, Event, EventResult};
+use crate::ui::gradient_border::GradientBorder;
 use crate::ui::prompt::{Completion, Prompt, PromptEvent};
-use crate::ui::{self, gradient_border::GradientBorder};
-use helix_core::{Position, unicode::width::UnicodeWidthStr};
+use helix_core::{unicode::width::UnicodeWidthStr, Position};
 use helix_view::{
+    editor::CmdlineStyle,
     graphics::{CursorKind, Rect},
     Editor,
-    editor::CmdlineStyle,
 };
 use std::borrow::Cow;
 use tui::{

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use helix_core::snippets::{ActiveSnippet, RenderedSnippet, Snippet};
-use helix_core::syntax::Highlight;
 use helix_core::{self as core, chars, fuzzy::MATCHER, Change, Transaction};
 use helix_lsp::{lsp, util, OffsetEncoding};
 use helix_view::editor::CompletionHighlightType;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -26,7 +26,7 @@ use helix_loader::VERSION_AND_GIT_HASH;
 use helix_view::{
     annotations::diagnostics::DiagnosticFilter,
     document::{Mode, SCRATCH_BUFFER_NAME},
-    editor::{CmdlineStyle, CompleteAction, CursorShapeConfig, InlineBlameConfig, InlineBlameShow},
+    editor::{CompleteAction, CursorShapeConfig, InlineBlameConfig, InlineBlameShow},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     icons::ICONS,
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
@@ -975,7 +975,6 @@ impl EditorView {
 
     /// Render bufferline at the top
     pub fn render_bufferline(&mut self, editor: &Editor, viewport: Rect, surface: &mut Surface) {
-        let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         self.bufferline_positions.clear();
         surface.clear_with(
             viewport,

--- a/helix-term/src/ui/gradient_border.rs
+++ b/helix-term/src/ui/gradient_border.rs
@@ -169,7 +169,7 @@ impl GradientBorder {
     }
 
     /// Render the gradient border around the given area
-    pub fn render(&mut self, area: Rect, surface: &mut Surface, theme: &Theme, rounded: bool) {
+    pub fn render(&mut self, area: Rect, surface: &mut Surface, _theme: &Theme, rounded: bool) {
         if !self.config.enable || area.width < 2 || area.height < 2 {
             return;
         }
@@ -261,7 +261,7 @@ impl GradientBorder {
     }
 
     /// Create a gradient border with default theme-based colors
-    pub fn from_theme(theme: &Theme, config: &GradientBorderConfig) -> Self {
+    pub fn from_theme(_theme: &Theme, config: &GradientBorderConfig) -> Self {
         let mut border_config = config.clone();
 
         // Use theme colors as fallbacks if hex colors are invalid

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -110,7 +110,7 @@ pub fn raw_regex_prompt(
 
     match config.cmdline.style {
         CmdlineStyle::Popup => {
-            let mut cmdline = CmdlinePopup::new(
+            let cmdline = CmdlinePopup::new(
                 prompt,
                 history_register,
                 completion_fn,

--- a/helix-vcs/src/git/blame.rs
+++ b/helix-vcs/src/git/blame.rs
@@ -92,7 +92,7 @@ impl FileBlame {
         let thread_safe_repo =
             open_repo(get_repo_dir(&file)?).context("Failed to open git repo")?;
         let repo = thread_safe_repo.to_thread_local();
-        let head = repo.head()?.peel_to_commit_in_place()?.id;
+        let head = repo.head()?.peel_to_commit()?.id;
 
         let mut resource_cache = repo.diff_resource_cache_for_tree_diff()?;
         let file_blame = gix::blame::file(


### PR DESCRIPTION
Just some house cleaning PR.

I checked the output of the: `cargo install --path helix-term --locked`
and fixed all the warnings.

This just helps to develop more easily as you can faster find the actual compile errors when they happen.

Tested on my machine and didn't find any regression.

Also @gj1118, we should discuss the notification features. I removed quite a few functions that were unused. Do we want to keep those in the codebase?