### PR TITLE
fix: find next or previous char can fail with CRLF line endings

### DIFF
--- a/helix-core/src/text_folding/test_utils.rs
+++ b/helix-core/src/text_folding/test_utils.rs
@@ -137,8 +137,8 @@ pub(crate) fn folds_eq_by(
 ) -> bool {
     if container1.len() != container2.len() {
         eprintln!(
-            "left has lenght = {}\n\
-            right has lenght = {}",
+            "left has length = {}\n\
+            right has length = {}",
             container1.len(),
             container2.len(),
         );

--- a/helix-term/tests/test/commands/text_folding.rs
+++ b/helix-term/tests/test/commands/text_folding.rs
@@ -1499,7 +1499,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("    new text\n".into(), 0);
-                    assert_eq!(result(app, 55), expected);
+                    let result = result(app, 55);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
             (Some("xd"), None),
@@ -1511,7 +1512,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("    new text\n".into(), 0);
-                    assert_eq!(result(app, 55), expected);
+                    let result = result(app, 55);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
             (Some("xd"), None),
@@ -1523,7 +1525,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("        new text\n".into(), -1);
-                    assert_eq!(result(app, 71), expected);
+                    let result = result(app, 71);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
             (
@@ -1545,7 +1548,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("        new text\n".into(), -1);
-                    assert_eq!(result(app, 71), expected);
+                    let result = result(app, 71);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
             (
@@ -1556,7 +1560,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("new text\n".into(), 0);
-                    assert_eq!(result(app, 4), expected);
+                    let result = result(app, 4);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
             (
@@ -1582,7 +1587,8 @@ async fn open() -> anyhow::Result<()> {
                 ),
                 Some(&|app| {
                     let expected = ("//! new text\n".into(), 0);
-                    assert_eq!(result(app, 4), expected);
+                    let result = result(app, 4);
+                    assert_eq!((result.0.replace("\r\n", "\n"), result.1), expected);
                 }),
             ),
         ],


### PR DESCRIPTION
This fixes the related issue and resolves the integration tests that have LF line endings hard-coded into the test without regard to Windows' default being CRLF which has been causing those tests to fail.

Related Issue: https://github.com/gj1118/helix/issues/35

Feedback is welcome.