### PR TITLE
fix(statusline): show function name in C/C++ files

### DIFF
--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -13,6 +13,7 @@ use helix_view::{
 use crate::ui::ProgressSpinners;
 
 use helix_view::editor::StatusLineElement as StatusLineElementID;
+use helix_core::{tree_sitter::Node as TsNode, RopeSlice};
 use std::sync::{LazyLock, Mutex};
 use tui::buffer::Buffer as Surface;
 use tui::text::{Span, Spans};
@@ -713,6 +714,48 @@ fn get_current_function_name_cached(context: &RenderContext) -> Option<String> {
     name
 }
 
+/// Extract a function name from a C/C++ declarator chain.
+///
+/// In C/C++, the function name is not a direct child of `function_definition`
+/// but is nested inside a declarator chain:
+///   function_definition → function_declarator → (qualified_identifier →)* identifier
+fn extract_name_from_declarator(node: TsNode<'_>, text: RopeSlice<'_>) -> Option<String> {
+    let kind = node.kind();
+    match kind {
+        "identifier" | "field_identifier" => {
+            let start_char = text.byte_to_char(node.start_byte() as usize);
+            let end_char = text.byte_to_char(node.end_byte() as usize);
+            Some(text.slice(start_char..end_char).to_string())
+        }
+        "qualified_identifier" => {
+            // Iterate in reverse to get the rightmost (innermost) identifier,
+            // stripping any namespace/class prefix (e.g. "trace::is_valid" → "is_valid").
+            for i in (0..node.child_count()).rev() {
+                if let Some(child) = node.child(i) {
+                    if child.kind() == "identifier" || child.kind() == "field_identifier" {
+                        let start_char = text.byte_to_char(child.start_byte() as usize);
+                        let end_char = text.byte_to_char(child.end_byte() as usize);
+                        return Some(text.slice(start_char..end_char).to_string());
+                    }
+                }
+            }
+            None
+        }
+        k if k.contains("declarator") => {
+            // Handles function_declarator, pointer_declarator, reference_declarator, etc.
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i) {
+                    if let Some(name) = extract_name_from_declarator(child, text) {
+                        return Some(name);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 fn get_current_function_name(context: &RenderContext) -> Option<String> {
     let syntax = context.doc.syntax()?;
     let text = context.doc.text().slice(..);
@@ -745,6 +788,18 @@ fn get_current_function_name(context: &RenderContext) -> Option<String> {
                         let end_char = text.byte_to_char(end_byte);
                         let name = text.slice(start_char..end_char).to_string();
                         return Some(name);
+                    }
+                }
+            }
+
+            // C/C++: name is inside a declarator chain
+            // e.g. function_definition → function_declarator → qualified_identifier → identifier
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i) {
+                    if child.kind().contains("declarator") {
+                        if let Some(name) = extract_name_from_declarator(child, text) {
+                            return Some(name);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- `function-name` statusline element was always blank for C and C++ files
- Root cause: `get_current_function_name()` only checked **direct children** of the function node for an `identifier`, but in C/C++ the name is nested inside a declarator chain
- Adds `extract_name_from_declarator()` to walk the chain recursively

## Root cause

In C/C++, tree-sitter represents a function like `bool trace::is_valid() const` as:

```
function_definition           ← matched (contains "function")
├── primitive_type "bool"
├── function_declarator       ← NOT an identifier
│   ├── qualified_identifier
│   │   ├── namespace_identifier "trace"
│   │   └── identifier "is_valid"   ← name is here, 2-3 levels deep
│   └── parameter_list
└── compound_statement        ← cursor is here
```

None of `function_definition`'s direct children have kind `identifier` or `field_identifier`, so no name was returned. Go, Rust, and TypeScript all place the name as a direct child of the function node, which is why they work.

## Fix

Added `extract_name_from_declarator()` which handles:

- `identifier` / `field_identifier` → returns the name directly
- `qualified_identifier` → returns the rightmost identifier, stripping namespace prefix (e.g. `trace::is_valid` → `is_valid`)
- Any other `*declarator*` node (pointer, reference, etc.) → recurses into children

The fallback is called from `get_current_function_name()` after the existing direct-child check, so all previously working languages are unaffected.

## Test plan

- [ ] Place cursor inside a simple C++ function (`void foo() {}`) — shows `foo`
- [ ] Place cursor inside a qualified method (`bool trace::is_valid() const {}`) — shows `is_valid`
- [ ] Verify Go, Rust, TypeScript still show correct function names