### PR TITLE
Fix debugger by integrating in changes from slawomirlech

### DIFF
--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -29,5 +29,9 @@ futures-util.workspace = true
 tokio-stream.workspace = true
 sonic-rs.workspace = true
 
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 fern = "0.7"

--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -117,14 +117,24 @@ impl Client {
         // Resolve path to the binary
         let cmd = helix_stdx::env::which(cmd)?;
 
-        let process = Command::new(cmd)
+        let mut command = Command::new(cmd);
+        command
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             // make sure the process is reaped on drop
-            .kill_on_drop(true)
-            .spawn();
+            .kill_on_drop(true);
+
+        #[cfg(unix)]
+        unsafe {
+            command.pre_exec(|| match libc::setsid() {
+                -1 => Err(std::io::Error::last_os_error()),
+                _ => Ok(()),
+            });
+        }
+
+        let process = command.spawn();
 
         let mut process = process?;
 
@@ -547,3 +557,4 @@ impl Client {
             .get(self.active_frame?)
     }
 }
+


### PR DESCRIPTION
I  didn't do anything - this was all work by @slawomirlech on this branch: [DAP: Fixed issue with debugpy corrupting terminal](https://github.com/helix-editor/helix/pull/15593) on the main helix repo

Seems like it only works on unix tho