### PR TITLE
putting fullscreen overlay behind a setting

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -165,7 +165,10 @@ impl Application {
             // If the first file is a directory, skip it and open a picker
             if let Some((first, _)) = files_it.next_if(|(p, _)| p.is_dir()) {
                 let picker = ui::file_picker(&editor, first);
-                compositor.push(Box::new(overlaid(picker)));
+                compositor.push(Box::new(overlaid(
+                    picker,
+                    editor.config().fullscreen_overlay,
+                )));
             }
 
             // If there are any more files specified, open them
@@ -899,7 +902,10 @@ impl Application {
                         );
                     })
                     .with_title("Plugin");
-                self.compositor.push(Box::new(overlaid(picker)));
+                self.compositor.push(Box::new(overlaid(
+                    picker,
+                    self.editor.config().fullscreen_overlay,
+                )));
             }
         }
     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1637,7 +1637,10 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         let path = &rel_path.join(path);
         if path.is_dir() {
             let picker = ui::file_picker(cx.editor, path.into());
-            cx.push_layer(Box::new(overlaid(picker)));
+            cx.push_layer(Box::new(overlaid(
+                picker,
+                cx.editor.config().fullscreen_overlay,
+            )));
         } else if let Err(e) = cx.editor.open(path, action) {
             cx.editor.set_error(format!("Open file failed: {:?}", e));
         }
@@ -1660,7 +1663,10 @@ fn open_url(cx: &mut Context, url: Url, action: Action) {
     let path = &rel_path.join(url.path());
     if path.is_dir() {
         let picker = ui::file_picker(cx.editor, path.into());
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     } else if let Err(e) = cx.editor.open(path, action) {
         cx.editor.set_error(format!("Open file failed: {:?}", e));
     }
@@ -1691,7 +1697,10 @@ fn open_url_in_callback(
     let path = &rel_path.join(url.path());
     if path.is_dir() {
         let picker = ui::file_picker(editor, path.into());
-        compositor.push(Box::new(overlaid(picker)));
+        compositor.push(Box::new(overlaid(
+            picker,
+            editor.config().fullscreen_overlay,
+        )));
     } else if let Err(e) = editor.open(path, action) {
         editor.set_error(format!("Open file failed: {:?}", e));
     }
@@ -2934,7 +2943,10 @@ fn global_search(cx: &mut Context) {
     .with_dynamic_query(get_files, Some(275))
     .with_title("Global Search");
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 /// Local grep search in buffer
@@ -3175,7 +3187,10 @@ fn local_search_grep(cx: &mut Context) {
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275))
     .with_title("Buffer Search");
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 fn local_search_fuzzy(cx: &mut Context) {
@@ -3324,7 +3339,10 @@ fn local_search_fuzzy(cx: &mut Context) {
         }
     }
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 enum Extend {
@@ -3752,7 +3770,10 @@ fn file_picker(cx: &mut Context) {
         };
         cx.push_layer(Box::new(overlay));
     } else {
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     }
 }
 
@@ -3779,7 +3800,10 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
     };
 
     let picker = ui::file_picker(cx.editor, path);
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 fn file_picker_in_current_directory(cx: &mut Context) {
@@ -3790,7 +3814,10 @@ fn file_picker_in_current_directory(cx: &mut Context) {
         return;
     }
     let picker = ui::file_picker(cx.editor, cwd);
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 fn file_explorer(cx: &mut Context) {
@@ -3801,7 +3828,10 @@ fn file_explorer(cx: &mut Context) {
     }
 
     if let Ok(picker) = ui::file_explorer(None, root, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     }
 }
 
@@ -3828,7 +3858,10 @@ fn file_explorer_in_current_buffer_directory(cx: &mut Context) {
     };
 
     if let Ok(picker) = ui::file_explorer(None, path, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     }
 }
 
@@ -3841,7 +3874,10 @@ fn file_explorer_in_current_directory(cx: &mut Context) {
     }
 
     if let Ok(picker) = ui::file_explorer(None, cwd, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     }
 }
 
@@ -3989,7 +4025,10 @@ fn buffer_picker(cx: &mut Context) {
         Some((meta.id.into(), lines))
     })
     .with_title("Buffers");
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 fn jumplist_picker(cx: &mut Context) {
@@ -4100,7 +4139,10 @@ fn jumplist_picker(cx: &mut Context) {
         Some((meta.id.into(), Some((line, line))))
     })
     .with_title("Jumplist");
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 fn changed_file_picker(cx: &mut Context) {
@@ -4219,7 +4261,10 @@ fn changed_file_picker(cx: &mut Context) {
                 true
             }
         });
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 pub fn command_palette(cx: &mut Context) {
@@ -4310,7 +4355,10 @@ pub fn command_palette(cx: &mut Context) {
                 }
             })
             .with_title("Command Palette");
-            compositor.push(Box::new(overlaid(picker)));
+            compositor.push(Box::new(overlaid(
+                picker,
+                cx.editor.config().fullscreen_overlay,
+            )));
         },
     ));
 }

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -292,6 +292,7 @@ pub fn dap_launch(cx: &mut Context) {
             }
         })
         .with_title("Debug Templates"),
+        cx.editor.config().fullscreen_overlay,
     )));
 }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -425,7 +425,7 @@ pub fn symbol_picker(cx: &mut Context) {
                 Err(err) => log::error!("Error requesting document symbols: {err}"),
             }
         }
-        let call = move |_editor: &mut Editor, compositor: &mut Compositor| {
+        let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             let columns = [
                 ui::PickerColumn::new("kind", |item: &SymbolInformationItem, _| {
                     let icons = ICONS.load();
@@ -473,7 +473,10 @@ pub fn symbol_picker(cx: &mut Context) {
             .truncate_start(false)
             .with_title("Document Symbols");
 
-            compositor.push(Box::new(overlaid(picker)))
+            compositor.push(Box::new(overlaid(
+                picker,
+                editor.config().fullscreen_overlay,
+            )))
         };
 
         Ok(Callback::EditorCompositor(Box::new(call)))
@@ -616,7 +619,10 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     .truncate_start(false)
     .with_title("Workspace Symbols");
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 pub fn diagnostics_picker(cx: &mut Context) {
@@ -625,7 +631,10 @@ pub fn diagnostics_picker(cx: &mut Context) {
         let diagnostics = cx.editor.diagnostics.get(&uri).cloned().unwrap_or_default();
         let picker = diag_picker(cx, [(uri, diagnostics)], DiagnosticsFormat::HideSourcePath)
             .with_title("Diagnostics");
-        cx.push_layer(Box::new(overlaid(picker)));
+        cx.push_layer(Box::new(overlaid(
+            picker,
+            cx.editor.config().fullscreen_overlay,
+        )));
     }
 }
 
@@ -634,7 +643,10 @@ pub fn workspace_diagnostics_picker(cx: &mut Context) {
     let diagnostics = cx.editor.diagnostics.clone();
     let picker = diag_picker(cx, diagnostics, DiagnosticsFormat::ShowSourcePath)
         .with_title("Workspace Diagnostics");
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 impl ui::menu::Item for CodeActionItem {
@@ -751,7 +763,10 @@ fn code_action_inner_picker(actions: Vec<CodeActionItem>) -> Result<Callback, an
             },
         )
         .with_title("Code Actions");
-        compositor.push(Box::new(overlaid(picker)));
+        compositor.push(Box::new(overlaid(
+            picker,
+            editor.config().fullscreen_overlay,
+        )));
     };
     Ok(Callback::EditorCompositor(Box::new(call)))
 }
@@ -1031,7 +1046,10 @@ fn goto_impl(
             })
             .with_preview(|_editor, location| location_to_file_location(location))
             .with_title(title);
-            compositor.push(Box::new(overlaid(picker)));
+            compositor.push(Box::new(overlaid(
+                picker,
+                editor.config().fullscreen_overlay,
+            )));
         }
     }
 }

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -217,7 +217,10 @@ pub fn syntax_symbol_picker(cx: &mut Context) {
     .truncate_start(false)
     .with_title("Document Symbols");
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
@@ -464,7 +467,10 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
     .with_history_register(Some(reg))
     .truncate_start(false)
     .with_title("Workspace Symbols");
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid(
+        picker,
+        cx.editor.config().fullscreen_overlay,
+    )));
 }
 
 /// Create a Rope and language config for a given existing path without creating a full Document.

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -161,7 +161,10 @@ fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow
                 let call: job::Callback = job::Callback::EditorCompositor(Box::new(
                     move |editor: &mut Editor, compositor: &mut Compositor| {
                         let picker = ui::file_picker(editor, path.into_owned());
-                        compositor.push(Box::new(overlaid(picker)));
+                        compositor.push(Box::new(overlaid(
+                            picker,
+                            editor.config().fullscreen_overlay,
+                        )));
                     },
                 ));
                 Ok(call)
@@ -1686,7 +1689,7 @@ fn lsp_workspace_command(
             .collect::<Vec<_>>();
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
-                move |_editor: &mut Editor, compositor: &mut Compositor| {
+                move |editor: &mut Editor, compositor: &mut Compositor| {
                     let columns = [ui::PickerColumn::new(
                         "title",
                         |(_ls_id, command): &(_, helix_lsp::lsp::Command), _| {
@@ -1703,7 +1706,10 @@ fn lsp_workspace_command(
                         },
                     )
                     .with_title("LSP Commands");
-                    compositor.push(Box::new(overlaid(picker)))
+                    compositor.push(Box::new(overlaid(
+                        picker,
+                        editor.config().fullscreen_overlay,
+                    )))
                 },
             ));
             Ok(call)

--- a/helix-term/src/ui/file_explorer.rs
+++ b/helix-term/src/ui/file_explorer.rs
@@ -128,7 +128,10 @@ fn refresh_file_explorer(cursor: u32, cx: &mut Context, root: PathBuf) {
             // replace the old file explorer with the new one
             compositor.pop();
             if let Ok(picker) = file_explorer(Some(cursor), root, editor) {
-                compositor.push(Box::new(overlay::overlaid(picker)));
+                compositor.push(Box::new(overlay::overlaid(
+                    picker,
+                    editor.config().fullscreen_overlay,
+                )));
             }
         }));
         Ok(call)
@@ -392,7 +395,10 @@ pub fn file_explorer(
                     let call: Callback =
                         Callback::EditorCompositor(Box::new(move |editor, compositor| {
                             if let Ok(picker) = file_explorer(None, new_root, editor) {
-                                compositor.push(Box::new(overlay::overlaid(picker)));
+                                compositor.push(Box::new(overlay::overlaid(
+                                    picker,
+                                    editor.config().fullscreen_overlay,
+                                )));
                             }
                         }));
                     Ok(call)

--- a/helix-term/src/ui/overlay.rs
+++ b/helix-term/src/ui/overlay.rs
@@ -17,12 +17,13 @@ pub struct Overlay<T> {
     pub calc_child_size: Box<dyn Fn(Rect) -> Rect>,
 }
 
-/// Surrounds the component with a margin of 5% on each side, and an additional 2 rows at the bottom
-pub fn overlaid<T>(content: T) -> Overlay<T> {
+/// Surrounds the component with a margin of 5% on each side, and an additional 2 rows at the bottom.
+/// When `fullscreen` is true, uses full screen width on terminals narrower than `FULL_OVERLAID_MAX_WIDTH`.
+pub fn overlaid<T>(content: T, fullscreen: bool) -> Overlay<T> {
     Overlay {
         content,
-        calc_child_size: Box::new(|rect: Rect| {
-            let percentage = if rect.width < FULL_OVERLAID_MAX_WIDTH {
+        calc_child_size: Box::new(move |rect: Rect| {
+            let percentage = if fullscreen && rect.width < FULL_OVERLAID_MAX_WIDTH {
                 100
             } else {
                 90

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -538,6 +538,9 @@ pub struct Config {
     /// Picker gradient border configuration
     #[serde(default)]
     pub gradient_borders: GradientBorderConfig,
+    /// Whether to show pickers in fullscreen mode. When true, pickers expand to
+    /// full screen width on terminals narrower than 200 columns. Defaults to false.
+    pub fullscreen_overlay: bool,
     /// Notification system configuration
     #[serde(default)]
     pub notifications: NotificationConfig,
@@ -1783,6 +1786,7 @@ impl Default for Config {
             gradient_borders: GradientBorderConfig::default(),
             notifications: NotificationConfig::default(),
             completion_highlight: CompletionHighlight::default(),
+            fullscreen_overlay: false,
             buffer_picker: BufferPickerConfig::default(),
             fold_textobjects: Vec::new(),
             insecure: false,


### PR DESCRIPTION
Here is the setting. 

<img width="354" height="59" alt="image" src="https://github.com/user-attachments/assets/ee93bbf7-6ef2-4618-aa2c-df1e9f21f431" />

For now only the global search behaves. We will need to implement this for other pickers as well
