### PR TITLE
Fold Style = Nvim UFO Style, where the whole background line is highlighted.

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -426,9 +426,9 @@ impl<'a> TextRenderer<'a> {
         }
     }
     pub fn fill_row_background(&mut self, visual_line: u16, bg_color: helix_view::graphics::Color) {
-        let screen_y = (self.viewport.y + visual_line);
+        let screen_y = self.viewport.y + visual_line;
         let start_x = self.viewport.x;
-        let end_x = (self.viewport.x + self.viewport.width);
+        let end_x = self.viewport.x + self.viewport.width;
 
         for x in start_x..end_x {
             // Grab a mutable reference to the single coordinate cell and mutate its bg color field

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -425,7 +425,18 @@ impl<'a> TextRenderer<'a> {
                 .set_string(x, y, &self.indent_guide_char, self.indent_guide_style);
         }
     }
+    pub fn fill_row_background(&mut self, visual_line: u16, bg_color: helix_view::graphics::Color) {
+        let screen_y = (self.viewport.y + visual_line);
+        let start_x = self.viewport.x;
+        let end_x = (self.viewport.x + self.viewport.width);
 
+        for x in start_x..end_x {
+            // Grab a mutable reference to the single coordinate cell and mutate its bg color field
+            if let Some(cell) = self.surface.get_mut(x, screen_y) {
+                cell.set_bg(bg_color);
+            }
+        }
+    }
     pub fn set_string(&mut self, x: u16, y: u16, string: &str, style: Style) {
         if (y as usize) < self.offset.row {
             return;

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -193,13 +193,19 @@ impl Decoration for Cursor<'_> {
 pub(crate) struct FoldDecoration<'a> {
     annotations: FoldAnnotations<'a>,
     style: Style,
+    text_rope: helix_core::Rope,
 }
-
 impl<'a> FoldDecoration<'a> {
-    pub(crate) fn new(annotations: &'a TextAnnotations<'a>, theme: &Theme) -> Self {
+    pub(crate) fn new(
+        annotations: &'a TextAnnotations<'a>,
+        theme: &Theme,
+        doc: &helix_view::Document,
+    ) -> Self {
         Self {
             annotations: annotations.folds.clone(),
             style: theme.get("ui.virtual.fold-decoration"),
+            // Clone the Rope container (cloning a Rope is O(1) and uses structural sharing)
+            text_rope: doc.text().clone(),
         }
     }
 }
@@ -221,25 +227,34 @@ impl<'a> Decoration for FoldDecoration<'a> {
             return Position::new(0, 0);
         };
 
+        // 1. Force the solid uniform background across the ENTIRE row using our new method
+        if let Some(bg_color) = self.style.bg {
+            renderer.fill_row_background(pos.visual_line, bg_color);
+        }
+
+        // 2. Let the text draw naturally where the syntax-highlighted code line stops
         let draw_col = virt_off.col as u16 + 1;
         let width = renderer.viewport.width;
+        let max_width = width.saturating_sub(draw_col) as usize;
+
         let text = {
             let mut text = Tendril::new();
             let len_lines = fold.end.line - fold.start.line + 1;
-            text.write_fmt(format_args!(
-                "...+{len_lines} {object} {measure}",
-                object = fold.object(),
-                measure = if len_lines > 1 { "lines" } else { "line" },
-            ))
-            .unwrap();
+
+            let tab_spaces = "    ";
+            let label = format!("{}+{}", tab_spaces, len_lines);
+
+            text.write_fmt(format_args!("{:<width$}", label, width = max_width))
+                .unwrap();
             text
         };
 
+        // 3. Render the trailing space ribbon and label on top of the modified surface background
         renderer.set_string_truncated(
             renderer.viewport.x + draw_col,
             pos.visual_line,
             &text,
-            width.saturating_sub(draw_col) as usize,
+            max_width,
             |_| self.style,
             true,
             false,

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -193,19 +193,15 @@ impl Decoration for Cursor<'_> {
 pub(crate) struct FoldDecoration<'a> {
     annotations: FoldAnnotations<'a>,
     style: Style,
-    text_rope: helix_core::Rope,
 }
 impl<'a> FoldDecoration<'a> {
     pub(crate) fn new(
         annotations: &'a TextAnnotations<'a>,
         theme: &Theme,
-        doc: &helix_view::Document,
     ) -> Self {
         Self {
             annotations: annotations.folds.clone(),
             style: theme.get("ui.virtual.fold-decoration"),
-            // Clone the Rope container (cloning a Rope is O(1) and uses structural sharing)
-            text_rope: doc.text().clone(),
         }
     }
 }
@@ -227,12 +223,12 @@ impl<'a> Decoration for FoldDecoration<'a> {
             return Position::new(0, 0);
         };
 
-        // 1. Force the solid uniform background across the ENTIRE row using our new method
+        // Solid Background
         if let Some(bg_color) = self.style.bg {
             renderer.fill_row_background(pos.visual_line, bg_color);
         }
 
-        // 2. Let the text draw naturally where the syntax-highlighted code line stops
+        // Text
         let draw_col = virt_off.col as u16 + 1;
         let width = renderer.viewport.width;
         let max_width = width.saturating_sub(draw_col) as usize;
@@ -241,15 +237,14 @@ impl<'a> Decoration for FoldDecoration<'a> {
             let mut text = Tendril::new();
             let len_lines = fold.end.line - fold.start.line + 1;
 
-            let tab_spaces = "    ";
-            let label = format!("{}+{}", tab_spaces, len_lines);
+            let label = format!(" +{}", len_lines);
 
             text.write_fmt(format_args!("{:<width$}", label, width = max_width))
                 .unwrap();
             text
         };
 
-        // 3. Render the trailing space ribbon and label on top of the modified surface background
+        // Tail
         renderer.set_string_truncated(
             renderer.viewport.x + draw_col,
             pos.visual_line,


### PR DESCRIPTION
<img width="1918" height="630" alt="image" src="https://github.com/user-attachments/assets/807114af-222f-4513-9e82-b20b66760fdd" />

Notes:

- This was vibe coded. 
- Am primarily a C++/Qt dev, so please check my work.
- Tested with tree Sitter, and works well enough with `textobjects.scm`
- Still no support for `folds.scm`

Plans: 
- Add Fold Side Markings.